### PR TITLE
Feat: MusicGen 기반 음악 생성 및 요약 저장을 위한 SpringBoot 백엔드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,20 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# === OS ===
+.DS_Store
+Thumbs.db
+
+# === Logs ===
+*.log
+logs/
+!logs/.keep
+
+# === Env / Properties / Secrets ===
+.env
+.env.*
+*.local
+application-local.yml
+application-*.yml
+application-*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// build.gradle
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/Config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/Config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.example.demo.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // 모든 요청 허용
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/demo/Config/WebConfig.java
+++ b/src/main/java/com/example/demo/Config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.example.demo.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000") // React 주소
+                        .allowedMethods("GET", "POST", "PUT", "DELETE");
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/demo/Controller/MusicController.java
+++ b/src/main/java/com/example/demo/Controller/MusicController.java
@@ -1,0 +1,54 @@
+package com.example.demo.Controller;
+
+import com.example.demo.DTO.MusicGenerateRequest;
+import com.example.demo.Entity.BaseMusic;
+import com.example.demo.Entity.MusicSummary;
+import com.example.demo.Repository.BaseMusicRepository;
+import com.example.demo.Repository.MusicSummaryRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/music")
+public class MusicController {
+
+    private final BaseMusicRepository baseMusicRepo;
+    private final MusicSummaryRepository summaryRepo;
+
+    public MusicController(BaseMusicRepository baseMusicRepo, MusicSummaryRepository summaryRepo) {
+        this.baseMusicRepo = baseMusicRepo;
+        this.summaryRepo = summaryRepo;
+    }
+
+    @PostMapping("/generate")
+    public ResponseEntity<?> generateMusic(@RequestBody MusicGenerateRequest request) {
+        String sessionId = request.getSessionId();
+        Integer userId = request.getUserId();
+        String title = request.getTitle();
+        String fileUrl = request.getFileUrl();
+
+        // 1. GPT 요약 조회
+        MusicSummary summary = summaryRepo.findBySessionId(sessionId)
+                .orElseThrow(() -> new RuntimeException("GPT 요약 없음"));
+
+        // 2. 기본 음악 저장
+        BaseMusic music = new BaseMusic();
+        music.setSessionId(sessionId);
+        music.setUserId(userId);
+        music.setTitle(title);
+        music.setFileUrl(fileUrl);
+
+        baseMusicRepo.save(music);
+
+        // 3. 응답 구성
+        Map<String, Object> response = new HashMap<>();
+        response.put("musicId", music.getId());
+        response.put("summary", summary.getSummaryText());
+        response.put("fileUrl", music.getFileUrl());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/demo/Controller/SummaryController.java
+++ b/src/main/java/com/example/demo/Controller/SummaryController.java
@@ -1,0 +1,57 @@
+package com.example.demo.Controller;
+
+import com.example.demo.DTO.MusicGenerateRequest;
+import com.example.demo.DTO.SummaryDTO;
+import com.example.demo.DTO.SummaryRequest;
+import com.example.demo.Entity.MusicSummary;
+import com.example.demo.Mapper.SummaryMapper;
+import com.example.demo.Repository.MusicSummaryRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/summary")
+public class SummaryController {
+
+    private final MusicSummaryRepository summaryRepo;
+
+    public SummaryController(MusicSummaryRepository summaryRepo) {
+        this.summaryRepo = summaryRepo;
+    }
+
+    // ✅ 요약 저장 API
+    @PostMapping
+    public ResponseEntity<?> saveSummary(@RequestBody SummaryRequest request) {
+        if (summaryRepo.existsBySessionId(request.getSessionId())) {
+            return ResponseEntity.badRequest().body("이미 존재하는 session_id입니다.");
+        }
+
+        MusicSummary summary = new MusicSummary();
+        summary.setSessionId(request.getSessionId());
+        summary.setSummaryText(request.getSummaryText());
+
+        summaryRepo.save(summary);
+        return ResponseEntity.ok("요약 저장 완료");
+    }
+
+    // ✅ 요약 조회 API
+    @PostMapping("/music/generate")
+    public ResponseEntity<?> generate(@RequestBody MusicGenerateRequest request) {
+        MusicSummary entity = summaryRepo.findBySessionId(request.getSessionId())
+                .orElseThrow(() -> new RuntimeException("요약 없음"));
+
+        SummaryDTO dto = SummaryMapper.toDTO(entity);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("summaryText", dto.getSummaryText());
+        response.put("sessionId", dto.getSessionId());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/demo/DTO/MusicGenerateRequest.java
+++ b/src/main/java/com/example/demo/DTO/MusicGenerateRequest.java
@@ -1,0 +1,13 @@
+package com.example.demo.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor // 이거 꼭 추가!
+public class MusicGenerateRequest {
+    private String sessionId;
+    private Integer userId;
+    private String title;
+    private String fileUrl;
+}

--- a/src/main/java/com/example/demo/DTO/SummaryDTO.java
+++ b/src/main/java/com/example/demo/DTO/SummaryDTO.java
@@ -1,0 +1,10 @@
+package com.example.demo.DTO;
+
+
+import lombok.Data;
+
+@Data
+public class SummaryDTO {
+    private String sessionId;
+    private String summaryText;
+}

--- a/src/main/java/com/example/demo/DTO/SummaryRequest.java
+++ b/src/main/java/com/example/demo/DTO/SummaryRequest.java
@@ -1,0 +1,11 @@
+package com.example.demo.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class SummaryRequest {
+    private String sessionId;
+    private String summaryText;
+}

--- a/src/main/java/com/example/demo/Entity/BaseMusic.java
+++ b/src/main/java/com/example/demo/Entity/BaseMusic.java
@@ -1,0 +1,34 @@
+package com.example.demo.Entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name="base_music")
+public class BaseMusic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name="session_id", length = 64)
+    private String sessionId;
+
+    @Column(name = "user_id")
+    private Integer userId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "file_url")
+    private String fileUrl;
+
+    //Getter,Setter,Constructor
+
+}

--- a/src/main/java/com/example/demo/Entity/MusicSummary.java
+++ b/src/main/java/com/example/demo/Entity/MusicSummary.java
@@ -1,0 +1,30 @@
+package com.example.demo.Entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "music_summary")
+public class MusicSummary {
+
+    @Id
+    @Column(name = "session_id", length = 64)
+    private String sessionId;
+
+    @Column(name = "summary_text", columnDefinition = "TEXT", nullable = false)
+    private String summaryText;
+
+    @Column(name = "created_at", insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private Timestamp createdAt;
+
+    // getter,setter, constructor 등 입력
+}

--- a/src/main/java/com/example/demo/Mapper/SummaryMapper.java
+++ b/src/main/java/com/example/demo/Mapper/SummaryMapper.java
@@ -1,0 +1,21 @@
+package com.example.demo.Mapper;
+
+import com.example.demo.DTO.SummaryDTO;
+import com.example.demo.Entity.MusicSummary;
+
+public class SummaryMapper {
+
+    public static SummaryDTO toDTO(MusicSummary entity) {
+        SummaryDTO dto = new SummaryDTO();
+        dto.setSessionId(entity.getSessionId());
+        dto.setSummaryText(entity.getSummaryText());
+        return dto;
+    }
+
+    public static MusicSummary toEntity(SummaryDTO dto) {
+        MusicSummary entity = new MusicSummary();
+        entity.setSessionId(dto.getSessionId());
+        entity.setSummaryText(dto.getSummaryText());
+        return entity;
+    }
+}

--- a/src/main/java/com/example/demo/Repository/BaseMusicRepository.java
+++ b/src/main/java/com/example/demo/Repository/BaseMusicRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.Repository;
+
+import com.example.demo.Entity.BaseMusic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BaseMusicRepository extends JpaRepository<BaseMusic, Integer> {
+}
+

--- a/src/main/java/com/example/demo/Repository/MusicSummaryRepository.java
+++ b/src/main/java/com/example/demo/Repository/MusicSummaryRepository.java
@@ -1,0 +1,13 @@
+package com.example.demo.Repository;
+
+import com.example.demo.Entity.MusicSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MusicSummaryRepository extends JpaRepository<MusicSummary, String> {
+    Optional<MusicSummary> findBySessionId(String sessionId);
+
+    boolean existsBySessionId(String sessionId);
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=demo
+spring.security.user.name=admin
+spring.security.user.password=admin

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/pamo_db?serverTimezone=Asia/Seoul
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
# 🌌 Pull Request

### 🍓 작업한 내용
- MusicGen AI와의 연동을 위한 백엔드 서버 Spring Boot 기반으로 구현
- 음악 생성 요청 및 요약 저장을 처리하는 기능 명확히 분리
- DTO, Entity, Repository, Controller, Mapper, Config 등 표준 레이어 구조로 설계

### 📁 디렉토리 구조 요약
📦src/main/java/com/example/demo
┣ 📂Config → 보안 및 CORS 설정
┣ 📂Controller → /generate, /summary 요청 처리
┣ 📂DTO → 요청/응답 데이터 구조 정의
┣ 📂Entity → DB 매핑용 엔티티 정의 (BaseMusic, MusicSummary)
┣ 📂Mapper → DTO ↔ Entity 변환 책임
┣ 📂Repository → JPA 기반 DB 액세스 인터페이스
┗ 📄 DemoApplication.java → Spring Boot main entry point

### 🕵️‍♀️ PR Point
- `Mapper` 분리를 통해 DTO ↔ Entity 변환 책임이 명확히 분리되어 유지보수 용이
- `MusicController`, `SummaryController` 단일 책임 원칙에 따라 역할 분리됨
- `SecurityConfig`는 현재 최소 구성만 되어 있으므로 향후 인증 적용 시 확장 고려